### PR TITLE
Update admin-addon-revisions.php

### DIFF
--- a/admin-addon-revisions.php
+++ b/admin-addon-revisions.php
@@ -236,7 +236,11 @@ class AdminAddonRevisionsPlugin extends Plugin {
   }
 
   private function debugMessage($msg) {
-    $this->grav['debugger']->addMessage($msg);
+    $admin_show_debug = $this->config->get(self::CONFIG_KEY . '.debug_output');
+    if($admin_show_debug){
+      $this->grav['debugger']->addMessage($msg);
+    }
+        //Else no debugMessage output
   }
 
   private function directoryToDate($dir) {


### PR DESCRIPTION
Drop any "addMessage" lines if show debug messages has been enabled so as to reduce output messages without messing with any of the plugin functionality