### PR TITLE
Fixed: RuntimeException (400) - Template "revisions.html.twig"

### DIFF
--- a/admin-addon-revisions.php
+++ b/admin-addon-revisions.php
@@ -60,6 +60,7 @@ class AdminAddonRevisionsPlugin extends Plugin {
     $this->enable([
       'onPageProcessed' => ['onPageProcessed', 0],
       'onAdminTwigTemplatePaths' => ['onAdminTwigTemplatePaths', 0],
+      'onTwigTemplatePaths' => ['onTwigTemplatePaths', 0],
       'onAdminTaskExecute' => ['onAdminTaskExecute', 0],
       'onTwigSiteVariables' => ['onTwigSiteVariables', 0],
       'onAdminMenu' => ['onAdminMenu', 0],
@@ -78,6 +79,14 @@ class AdminAddonRevisionsPlugin extends Plugin {
       'location' => self::PAGE_LOCATION,
       'icon' => 'fa-file-text'
     ];
+  }
+
+  /**
+   * Add current directory to twig lookup paths.
+   */
+  public function onTwigTemplatePaths()
+  {
+      $this->grav['twig']->twig_paths[] = __DIR__ . '/templates';
   }
 
   public function onAdminTwigTemplatePaths($e) {


### PR DESCRIPTION
With Admin Plugin Revisions v1.3.3, opening the Revisions link in the Admin navigation sidebar cause the following error:
```
RuntimeException (400)
Template "revisions.html.twig" is not defined.
```
This raises the question why `onAdminTwigTemplatePaths` does not work.