### PR TITLE
Rename autoload method since it's a reserved name in GRAV 1.7.

### DIFF
--- a/admin-addon-revisions.php
+++ b/admin-addon-revisions.php
@@ -32,7 +32,7 @@ class AdminAddonRevisionsPlugin extends Plugin {
     return self::$instance;
   }
 
-  private function autoload($namespace, $folders) {
+  private function _autoload($namespace, $folders) {
     if ($this->loader === null) {
       $this->loader = new ClassLoader();
     }
@@ -46,7 +46,7 @@ class AdminAddonRevisionsPlugin extends Plugin {
   }
 
   public function onPluginsInitialized() {
-    $this->autoload('AdminAddonRevisions', array(__DIR__ . '/src/'));
+    $this->_autoload('AdminAddonRevisions', array(__DIR__ . '/src/'));
     self::$instance = $this;
 
     $this->directoryName = $this->config->get($this->configKey() . '.directory', '.revs');


### PR DESCRIPTION
Fixes compatibility with GRAV 1.7.0-rc.6.